### PR TITLE
correct example to pass validation

### DIFF
--- a/schemas/stsci.edu/yaml-schema/examples/invoice.yaml
+++ b/schemas/stsci.edu/yaml-schema/examples/invoice.yaml
@@ -14,16 +14,16 @@ examples:
             %TAG ! tag:stsci.edu:yaml-schema/examples/
             --- !invoice
             invoice: 34843
-            date   : 2001-01-23
+            date   : "2001-01-23"
             bill-to: &id001
-                - name: Chris Dumars
-                - address:
-                    - lines: |
-                        458 Walkman Dr.
-                        Suite #292
-                    - city: Royal Oak
-                    - state: MI
-                    - postal: 48046
+                name: Chris Dumars
+                address:
+                  lines: |
+                    458 Walkman Dr.
+                    Suite #292
+                  city: Royal Oak
+                  state: MI
+                  postal: "48046"
             ship-to: *id001
             product:
                 - sku         : BL394D


### PR DESCRIPTION
The example provided does not validate. 

The date is automatically import as a datetime instance instead of a string -> modified to be a string
The bill to has two lists instead of object as defined in the schema (corrected)
The postal keyword is see as an integer instead of a string -> modified